### PR TITLE
Renamed useAuthService and added backendURL param, added getAuthorizationHeader

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 - For React:18 on NodeJS:18
 - For Keycloak Gold Standard.
 - Works with Vanilla JavaScript or Typescript 5.
-- Currenly requires a proxy pass to the api with `/api`.
+- **BY DEFUALT**, set to work with a proxy pass to the backend using `/api`.
+- **To use without a proxy pass**, refer to the notes in the setup documentation below regarding optional parameters and property of `getLoginURL`, `getLogoutURL`, and `KeycloakWrapper`.
 - For use with [@bcgov/keycloak-express]
 
 <br />
@@ -33,6 +34,8 @@
 ```JSON
 "@bcgov/keycloak-react": "https://github.com/bcgov/keycloak-react/releases/download/v1.0.0-alpha.1/bcgov-keycloak-react.tgz",
 ```
+
+<br />
 
 2. Add import `import { KeycloakProvider } from '@bcgov/keycloak-react';` to `main.tsx` file or wherever the `createRoot()` function is. Wrap `<KeycloakProvider>` component around the Router or Routes like shown below:
 
@@ -56,6 +59,8 @@ root.render(
 );
 ```
 
+<br />
+
 3. Add import `import { KeycloakWrapper } from '@bcgov/keycloak-react';` to `AppRouter.tsx` file or wherever your routes are defined. Wrap `<KeycloakWrapper>` around Routes inside of Router like this example using `react-router-dom`:
 
 ```JavaScript
@@ -72,6 +77,10 @@ root.render(
   </KeycloakWrapper> // <--------------------------------------
 </Router>
 ```
+
+**NOTE**: _KeycloakWrapper has optional property `backendURL` (string), defaults to '/api'._
+
+<br />
 
 4. Use the following example to implement a login and logout button.
 
@@ -99,6 +108,8 @@ const HomePage = () => {
   );
 };
 ```
+
+**NOTE**: _getLoginURL and getLogoutURL have optional param 'backendURL' (string), defaults to '/api'._
 
 <br />
 
@@ -139,13 +150,13 @@ import {
 // Use the useKeycloak() hook within a React component:
 const {
   state, // Access the current user with state.userInfo
-  getLoginURL, // Returns the login route.
-  getLogoutURL, // Returns the logout route.
+  getLoginURL, // Returns the login route. Optional param 'backendURL' (string).
+  getLogoutURL, // Returns the logout route. Optional param 'backendURL' (string).
   getAuthorizationHeader, // Returns the value for the 'Authorization' header when making requests to protected endpoints.
   hasRole, // Pass a role in the form of a string to tell if the user has the given client_role.
   setUserInfo, // Shouldn't need to be used in your code.
-  refreshAccessToken, // Shouldn't need to be used in your code.
-} = useKeycloak(backendURL?: string); // (optional) Default's to '/api'.
+  refreshAccessToken, // Shouldn't need to be used in your code. Optional property 'backendURL' (string).
+} = useKeycloak();
 
 // Typescript Types - these shouldn't need to be used in your code.
 import {

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@
 ## Table of Contents
 
 - [General Information](#general-information)
-- [Getting Started with the Integration](#getting-started-with-the-integration)
-- [Module Exports](#module-exports)
+- [Getting Started with the Integration](#getting-started-with-the-integration) - Start Here!
+- [Module Exports](#module-exports) - Functions and Types available from the module.
+- [Authentication Flow](#authentication-flow) - How it works from login button click.
 
 ## General Information
 
@@ -22,6 +23,8 @@
 - Works with Vanilla JavaScript or Typescript 5.
 - Currenly requires a proxy pass to the api with `/api`.
 - For use with [@bcgov/keycloak-express]
+
+<br />
 
 ## Getting Started with the Integration
 
@@ -76,6 +79,7 @@ root.render(
 import { useAuthService } from '@bcgov/keycloak-react';
 
 const HomePage = () => {
+  // state is aliased as authState
   const { state: authState, getLoginURL, getLogoutURL } = useAuthService();
   const user = authState.userInfo;
 
@@ -98,7 +102,7 @@ const HomePage = () => {
 
 <br />
 
-For all user properties reference: https://github.com/bcgov/sso-keycloak/wiki/Identity-Provider-Attribute-Mapping  
+For all user properties reference [SSO Keycloak Wiki - Identity Provider Attribute Mapping].  
 Example IDIR `state.userInfo` object:
 
 ```JSON
@@ -115,6 +119,8 @@ Example IDIR `state.userInfo` object:
   "client_roles": ["admin"]
 }
 ```
+
+[Return to Top](#bcgov-sso-keycloak-frontend-integration)
 
 <br />
 
@@ -149,6 +155,43 @@ import {
 } from '@bcgov/keycloak-react';
 ```
 
+[Return to Top](#bcgov-sso-keycloak-frontend-integration)
+
+<br/>
+
+## Authentication Flow
+
+The Keycloak Authentication system begins when the user visits the frontend application.
+
+1. The user visits the frontend of the application. Here, the `KeycloakWrapper` component initializes and checks the URL for a query parameter named `token`.
+
+- If the `token` query parameter is found:
+
+  - The component strips the URL of the access token.
+  - The user's information is set into the state using the token.
+  - The user can now access the frontend of the application.
+
+- If the `token` query parameter is not found, the component checks if the user is logged in by using the refresh token to get a new access token by communicating with the `/api/oauth/token` endpoint.
+  - If the refresh token exists and is valid, the user can now access the frontend of the application without seeing the login button, as their session is authenticated through the refresh token.
+  - If the refresh token doesn't exist or is invalid, the login button is displayed.
+
+2. When the user clicks the login button, they are routed to the `/api/oauth/login` endpoint via a proxy pass, which then redirects them to the Keycloak login page.
+
+3. Upon successful login at the Keycloak login page, Keycloak redirects the user to the `/oauth/login/callback` endpoint.
+
+4. The authentication code returned by the callback endpoint is used to retrieve the access token and the refresh token for the user.
+
+5. The user is redirected back to the frontend with the access token included as a `token` query parameter and the refresh token set as an httpOnly cookie.
+
+6. The `KeycloakWrapper` component re-initiates and the process repeats from step 1, this time with the `token` query parameter available.
+
+<img width="100%" src="https://github.com/bcgov/keycloak-react/assets/16313579/08c5d42a-b08a-46db-9e13-157417b6df3c">
+
+[Return to Top](#bcgov-sso-keycloak-frontend-integration)
+
 <!-- Link References -->
 
+[access token]: https://auth0.com/docs/secure/tokens/access-tokens
+[refresh token]: https://developer.okta.com/docs/guides/refresh-tokens/main/
 [@bcgov/keycloak-express]: https://github.com/bcgov/keycloak-express
+[SSO Keycloak Wiki - Identity Provider Attribute Mapping]: https://github.com/bcgov/sso-keycloak/wiki/Identity-Provider-Attribute-Mapping

--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ root.render(
 4. Use the following example to implement a login and logout button.
 
 ```JavaScript
-import { useAuthService } from '@bcgov/keycloak-react';
+import { useKeycloak } from '@bcgov/keycloak-react';
 
 const HomePage = () => {
   // state is aliased as authState
-  const { state: authState, getLoginURL, getLogoutURL } = useAuthService();
+  const { state: authState, getLoginURL, getLogoutURL } = useKeycloak();
   const user = authState.userInfo;
 
   return (
@@ -132,19 +132,20 @@ These are the functions and types exported by the `@bcgov/keycloak-react` module
 import {
   KeycloakWrapper, // Provides the login and refresh token functionality.
   KeycloakProvider, // Provides state management for Keycloak.
-  useAuthState, // See below for usage.
+  useKeycloak, // See below for usage.
   AuthContext, // Shouldn't need to be used in your code.
 } from '@bcgov/keycloak-react';
 
-// Use the useAuthState() hook within a React component:
+// Use the useKeycloak() hook within a React component:
 const {
   state, // Access the current user with state.userInfo
   getLoginURL, // Returns the login route.
   getLogoutURL, // Returns the logout route.
+  getAuthorizationHeader, // Returns the value for the 'Authorization' header when making requests to protected endpoints.
   hasRole, // Pass a role in the form of a string to tell if the user has the given client_role.
   setUserInfo, // Shouldn't need to be used in your code.
   refreshAccessToken, // Shouldn't need to be used in your code.
-} = useAuthService();
+} = useKeycloak(backendURL?: string); // (optional) Default's to '/api'.
 
 // Typescript Types - these shouldn't need to be used in your code.
 import {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Table of Contents
 
 - [General Information](#general-information)
-- [Getting Started with the Integration](#getting-started-with-the-integration) - Start Here!
+- [Getting Started with the Integration](#getting-started-with-the-integration) - **Start Here!**
 - [Module Exports](#module-exports) - Functions and Types available from the module.
 - [Authentication Flow](#authentication-flow) - How it works from login button click.
 
@@ -78,7 +78,7 @@ root.render(
 </Router>
 ```
 
-**NOTE**: _KeycloakWrapper has optional property `backendURL` (string), defaults to '/api'._
+> **Note**: _KeycloakWrapper has optional property `backendURL` (string), defaults to '/api'._
 
 <br />
 
@@ -109,7 +109,7 @@ const HomePage = () => {
 };
 ```
 
-**NOTE**: _getLoginURL and getLogoutURL have optional param 'backendURL' (string), defaults to '/api'._
+> **Note**: _getLoginURL and getLogoutURL have optional param 'backendURL' (string), defaults to '/api'._
 
 <br />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/keycloak-react",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "BCGov Pathfinder SSO Keycloak integration for React",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/KeycloakWrapper.jsx
+++ b/src/KeycloakWrapper.jsx
@@ -1,23 +1,23 @@
-import React, { useEffect } from 'react';
+import React, { useEffect } from "react";
 
-import useAuthService from './service/useAuthService';
+import useKeycloak from "./service/useKeycloak";
 
 export const KeycloakWrapper = (props) => {
   const { children } = props;
-  const { setUserInfo, refreshAccessToken } = useAuthService();
+  const { setUserInfo, refreshAccessToken } = useKeycloak();
 
   useEffect(() => {
     // Get the current URL and its search parameters
     const url = new URL(window.location.href);
     const searchParams = url.searchParams;
-    const token = searchParams.get('token');
+    const token = searchParams.get("token");
 
     if (token) {
       setUserInfo(token);
-      searchParams.delete('token');
+      searchParams.delete("token");
       // Create a new URL with the updated search parameters
       const newUrl = `${url.origin}${url.pathname}${searchParams.toString()}`;
-      window.history.pushState({}, '', newUrl);
+      window.history.pushState({}, "", newUrl);
     } else {
       // If there is no token in the URL, try to refresh the access token
       refreshAccessToken();

--- a/src/KeycloakWrapper.jsx
+++ b/src/KeycloakWrapper.jsx
@@ -3,7 +3,7 @@ import React, { useEffect } from "react";
 import useKeycloak from "./service/useKeycloak";
 
 export const KeycloakWrapper = (props) => {
-  const { children } = props;
+  const { children, backendURL } = props;
   const { setUserInfo, refreshAccessToken } = useKeycloak();
 
   useEffect(() => {
@@ -20,7 +20,7 @@ export const KeycloakWrapper = (props) => {
       window.history.pushState({}, "", newUrl);
     } else {
       // If there is no token in the URL, try to refresh the access token
-      refreshAccessToken();
+      refreshAccessToken(backendURL);
     }
   }, []);
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ interface KeycloakProviderProps {
 }
 interface KeycloakWrapperProps {
   children: ReactNode;
+  backendURL?: string;
 }
 
 // Interface that extends the AuthState interface and adds a dispatch function.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
-import { Context, Dispatch, ReactNode } from 'react';
+import { Context, Dispatch, ReactNode } from "react";
 
-import { AuthAction, AuthState } from './service';
+import { AuthAction, AuthState } from "./service";
 
 // PROPS
 interface KeycloakProviderProps {
@@ -19,8 +19,12 @@ export interface AuthStateWithDispatch extends AuthState {
 export declare const AuthContext: Context<AuthState>;
 
 // FUNCTIONS
-export declare function KeycloakProvider(props: KeycloakProviderProps): JSX.Element;
-export declare function KeycloakWrapper(props: KeycloakWrapperProps): JSX.Element;
+export declare function KeycloakProvider(
+  props: KeycloakProviderProps
+): JSX.Element;
+export declare function KeycloakWrapper(
+  props: KeycloakWrapperProps
+): JSX.Element;
 
 // Exported types from ./service
-export { AuthAction, AuthState, AuthActionType, useAuthService } from './service';
+export { AuthAction, AuthState, AuthActionType, useKeycloak } from "./service";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export { KeycloakProvider } from './KeycloakProvider';
-export { KeycloakWrapper } from './KeycloakWrapper';
-export { useAuthService } from './service/useAuthService';
-export { AuthContext } from './KeycloakProvider';
+export { KeycloakProvider } from "./KeycloakProvider";
+export { KeycloakWrapper } from "./KeycloakWrapper";
+export { useKeycloak } from "./service/useKeycloak";
+export { AuthContext } from "./KeycloakProvider";

--- a/src/service/index.d.ts
+++ b/src/service/index.d.ts
@@ -7,12 +7,12 @@ export enum AuthActionType {
 
 declare interface AuthService {
   state: AuthState;
-  getLoginURL: () => string;
-  getLogoutURL: () => string;
+  getLoginURL: (backendURL?: string) => string;
+  getLogoutURL: (backendURL?: string) => string;
   getAuthorizationHeader: () => string;
   setUserInfo: (token: string) => void;
   hasRole: (role: string) => boolean;
-  refreshAccessToken: () => Promise<void>;
+  refreshAccessToken: (backendURL?: string) => Promise<void>;
 }
 
 export declare interface AuthState {
@@ -28,5 +28,5 @@ export declare interface AuthAction {
 declare const initialState: AuthState;
 
 // FUNCTIONS
-export declare function useKeycloak(backendURL: string): AuthService;
+export declare function useKeycloak(): AuthService;
 declare function reducer(state: AuthState, action: AuthAction): AuthState;

--- a/src/service/index.d.ts
+++ b/src/service/index.d.ts
@@ -1,14 +1,15 @@
 // Defines the possible types of authentication actions.
 export enum AuthActionType {
-  LOGIN = 'LOGIN',
-  LOGOUT = 'LOGOUT',
-  SET_TOKEN = 'SET_TOKEN',
+  LOGIN = "LOGIN",
+  LOGOUT = "LOGOUT",
+  SET_TOKEN = "SET_TOKEN",
 }
 
 declare interface AuthService {
   state: AuthState;
   getLoginURL: () => string;
   getLogoutURL: () => string;
+  getAuthorizationHeader: () => string;
   setUserInfo: (token: string) => void;
   hasRole: (role: string) => boolean;
   refreshAccessToken: () => Promise<void>;
@@ -27,5 +28,5 @@ export declare interface AuthAction {
 declare const initialState: AuthState;
 
 // FUNCTIONS
-export declare function useAuthService(): AuthService;
+export declare function useKeycloak(backendURL: string): AuthService;
 declare function reducer(state: AuthState, action: AuthAction): AuthState;

--- a/src/service/useKeycloak.js
+++ b/src/service/useKeycloak.js
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "react";
 
 import { AuthContext } from "../KeycloakProvider";
 import decodeJWT from "../utils/decodeJWT";
-import { AuthActionType } from "./index.d.ts";
+import { AuthActionType } from ".";
 
 const { SET_TOKEN } = AuthActionType;
 
@@ -11,14 +11,17 @@ const { SET_TOKEN } = AuthActionType;
  * @returns {Object} - An object containing authentication-related functions
  * and the current authentication state.
  */
-export const useAuthService = () => {
+export const useKeycloak = (backendURL = "/api") => {
   // Get the authentication state and dispatch function from the authentication context.
   const { state, dispatch } = useContext(AuthContext);
 
   // Use useMemo to memoize the returned object and prevent unnecessary re-renders.
   return useMemo(() => {
-    const getLoginURL = () => "/api/oauth/login";
-    const getLogoutURL = () => "/api/oauth/logout";
+    const getLoginURL = () => new URL(backendURL, "/oauth/login");
+    const getLogoutURL = () => new URL(backendURL, "/oauth/logout");
+
+    // Return Authorization Header for Keycloak requests.
+    const getAuthorizationHeader = () => `Bearer ${state.accessToken}`;
 
     // Sets the user information in the authentication state using a JWT token.
     const setUserInfo = (token) => {
@@ -35,24 +38,35 @@ export const useAuthService = () => {
 
     // Get a new access token using the refresh token.
     const refreshAccessToken = async () => {
-      const response = await fetch("/api/oauth/token", {
-        method: "POST",
-        credentials: "include",
-      });
+      const fetchURL = new URL(backendURL, "/oauth/token");
 
-      if (response.ok) {
-        const { access_token } = await response.json();
-        const decodedToken = decodeJWT(access_token);
-        dispatch({
-          type: SET_TOKEN,
-          payload: { accessToken: access_token, userInfo: decodedToken },
+      try {
+        const response = await fetch(fetchURL, {
+          method: "POST",
+          credentials: "include",
         });
+
+        if (response.ok) {
+          const { access_token } = await response.json();
+          const decodedToken = decodeJWT(access_token);
+          dispatch({
+            type: SET_TOKEN,
+            payload: { accessToken: access_token, userInfo: decodedToken },
+          });
+        } else {
+          // Something went wrong, response was not ok.
+          throw new Error(response);
+        }
+      } catch (error) {
+        // Log error.
+        console.error("@bcgov/keycloak-react, refreshAccessToken error", error);
       }
     };
 
     return {
       getLoginURL,
       getLogoutURL,
+      getAuthorizationHeader,
       setUserInfo,
       refreshAccessToken,
       hasRole,
@@ -61,4 +75,4 @@ export const useAuthService = () => {
   }, [state]);
 };
 
-export default useAuthService;
+export default useKeycloak;

--- a/src/service/useKeycloak.js
+++ b/src/service/useKeycloak.js
@@ -17,10 +17,10 @@ export const useKeycloak = () => {
 
   // Use useMemo to memoize the returned object and prevent unnecessary re-renders.
   return useMemo(() => {
-    const getLoginURL = (backendURL = "/api") =>
-      new URL(backendURL, "/oauth/login");
-    const getLogoutURL = (backendURL = "/api") =>
-      new URL(backendURL, "/oauth/logout");
+    const getLoginURL = (backendURL) =>
+      new URL(backendURL ?? "/api", "/oauth/login");
+    const getLogoutURL = (backendURL) =>
+      new URL(backendURL ?? "/api", "/oauth/logout");
 
     // Return Authorization Header for Keycloak requests.
     const getAuthorizationHeader = () => `Bearer ${state.accessToken}`;
@@ -39,8 +39,8 @@ export const useKeycloak = () => {
       state.userInfo?.client_roles?.includes(role) ?? false;
 
     // Get a new access token using the refresh token.
-    const refreshAccessToken = async (backendURL = "/api") => {
-      const fetchURL = new URL(backendURL, "/oauth/token");
+    const refreshAccessToken = async (backendURL) => {
+      const fetchURL = new URL(backendURL ?? "/api", "/oauth/token");
 
       try {
         const response = await fetch(fetchURL, {

--- a/src/service/useKeycloak.js
+++ b/src/service/useKeycloak.js
@@ -17,10 +17,8 @@ export const useKeycloak = () => {
 
   // Use useMemo to memoize the returned object and prevent unnecessary re-renders.
   return useMemo(() => {
-    const getLoginURL = (backendURL) =>
-      new URL(backendURL ?? "/api", "/oauth/login");
-    const getLogoutURL = (backendURL) =>
-      new URL(backendURL ?? "/api", "/oauth/logout");
+    const getLoginURL = (backendURL) => `${backendURL ?? "/api"}/oauth/login`;
+    const getLogoutURL = (backendURL) => `${backendURL ?? "/api"}/oauth/logout`;
 
     // Return Authorization Header for Keycloak requests.
     const getAuthorizationHeader = () => `Bearer ${state.accessToken}`;
@@ -40,7 +38,7 @@ export const useKeycloak = () => {
 
     // Get a new access token using the refresh token.
     const refreshAccessToken = async (backendURL) => {
-      const fetchURL = new URL(backendURL ?? "/api", "/oauth/token");
+      const fetchURL = `${backendURL ?? "/api"}/oauth/token`;
 
       try {
         const response = await fetch(fetchURL, {
@@ -55,9 +53,6 @@ export const useKeycloak = () => {
             type: SET_TOKEN,
             payload: { accessToken: access_token, userInfo: decodedToken },
           });
-        } else {
-          // Something went wrong, response was not ok.
-          throw new Error(response);
         }
       } catch (error) {
         // Log error.

--- a/src/service/useKeycloak.js
+++ b/src/service/useKeycloak.js
@@ -11,14 +11,16 @@ const { SET_TOKEN } = AuthActionType;
  * @returns {Object} - An object containing authentication-related functions
  * and the current authentication state.
  */
-export const useKeycloak = (backendURL = "/api") => {
+export const useKeycloak = () => {
   // Get the authentication state and dispatch function from the authentication context.
   const { state, dispatch } = useContext(AuthContext);
 
   // Use useMemo to memoize the returned object and prevent unnecessary re-renders.
   return useMemo(() => {
-    const getLoginURL = () => new URL(backendURL, "/oauth/login");
-    const getLogoutURL = () => new URL(backendURL, "/oauth/logout");
+    const getLoginURL = (backendURL = "/api") =>
+      new URL(backendURL, "/oauth/login");
+    const getLogoutURL = (backendURL = "/api") =>
+      new URL(backendURL, "/oauth/logout");
 
     // Return Authorization Header for Keycloak requests.
     const getAuthorizationHeader = () => `Bearer ${state.accessToken}`;
@@ -37,7 +39,7 @@ export const useKeycloak = (backendURL = "/api") => {
       state.userInfo?.client_roles?.includes(role) ?? false;
 
     // Get a new access token using the refresh token.
-    const refreshAccessToken = async () => {
+    const refreshAccessToken = async (backendURL = "/api") => {
       const fetchURL = new URL(backendURL, "/oauth/token");
 
       try {

--- a/src/service/useKeycloak.js
+++ b/src/service/useKeycloak.js
@@ -2,7 +2,7 @@ import { useContext, useMemo } from "react";
 
 import { AuthContext } from "../KeycloakProvider";
 import decodeJWT from "../utils/decodeJWT";
-import { AuthActionType } from ".";
+import { AuthActionType } from "./index.d.ts";
 
 const { SET_TOKEN } = AuthActionType;
 


### PR DESCRIPTION
## 🎯 Summary

- [BREAKING] Renamed `useAuthService()` to `useKeycloak()`
- Added `backendURL` optional param to `useLoginURL()` and `useLogoutURL()`, defaults to `/api`.
- Added `backendURL` optional property to `KeycloakWrapper`, defaults to `/api`.
- Added `getAuthorizationHeader()` to exports of `useKeycloak()` to be used when making requests to your protected backend routes.